### PR TITLE
fix: import package paths and compensating for AlgoSDK remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ cd bip32-ed25519-kotlin
 cd ..
 cp bip32-ed25519-kotlin/build/*-release.aar arc52-android-wallet/app/libs/
 ```
+
+## Send a Transaction
+
+Note that the default seed `exact remain north lesson program series excess lava material second riot error boss planet brick rotate scrap army riot banner adult fashion casino bamboo` should NOT be used in production.
+
+However, for testing the app, this seed produces the Algorand address `I7V63MENRB7L4K53PQGYRFQFI7ZWXD3N53XIGP5THNNT6BSAYWBFYGX4DE`. Funding it in your default local algokit sandbox environment (the default algod this app references too) should allow the app to make a successful transaction. If you don't fund it the app will simply return fail rather than providing transaction id.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ git clone git@github.com:algorandfoundation/bip32-ed25519-kotlin.git
 cd bip32-ed25519-kotlin
 ./initialize.sh
 cd ..
-cp bip32-ed25519-kotlin/android/bip32ed25519/build/outputs/aar/*-release.aar arc52-android-wallet/app/libs/
+cp bip32-ed25519-kotlin/build/*-release.aar arc52-android-wallet/app/libs/
 ```

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.algorandfoundation.arc52_android_wallet"
-        minSdkVersion 34
+        minSdkVersion 29
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/algorandfoundation/arc52_android_wallet/Wallet.kt
+++ b/app/src/main/java/com/algorandfoundation/arc52_android_wallet/Wallet.kt
@@ -25,6 +25,8 @@ import com.algorand.algosdk.crypto.Address
 import com.algorand.algosdk.transaction.Transaction
 import com.algorand.algosdk.util.Encoder
 import com.algorand.algosdk.v2.client.common.AlgodClient
+import com.algorand.algosdk.crypto.Signature
+import com.algorand.algosdk.transaction.SignedTransaction
 import com.algorandfoundation.arc52_android_wallet.databinding.WalletBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -270,7 +272,28 @@ class Wallet : Fragment() {
                                 .noteUTF8(note)
                                 .build()
 
-                val stx = bip32Ed25519?.signAlgoTransaction(KeyContext.Address, 0u, 0u, 0u, tx)
+                val pkAddress = Address(bip32Ed25519?.keyGen(
+                    KeyContext.Address,
+                    0u,
+                    0u,
+                    0u,
+                ))
+                val txSig =
+                    Signature(
+                        bip32Ed25519?.signAlgoTransaction(
+                            KeyContext.Address,
+                            0u,
+                            0u,
+                            0u,
+                            tx.bytesToSign()
+                        )
+                    )
+
+                val stx = SignedTransaction(tx, txSig, tx.txID())
+
+                if (tx.sender != pkAddress) {
+                    stx.authAddr(pkAddress)
+                }
                 val stxBytes = Encoder.encodeToMsgPack(stx)
 
                 Log.d("stxBytes", stxBytes.toString())

--- a/app/src/main/java/com/algorandfoundation/arc52_android_wallet/Wallet.kt
+++ b/app/src/main/java/com/algorandfoundation/arc52_android_wallet/Wallet.kt
@@ -16,8 +16,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import bip32ed25519.Bip32Ed25519Android
-import bip32ed25519.KeyContext
+import com.algorandfoundation.bip32ed25519.Bip32Ed25519Android
+import com.algorandfoundation.bip32ed25519.KeyContext
 import cash.z.ecc.android.bip39.Mnemonics
 import cash.z.ecc.android.bip39.Mnemonics.MnemonicCode
 import cash.z.ecc.android.bip39.toSeed


### PR DESCRIPTION
- Makes sure that its com.algorandfoundation.bip32ed25519
- Updates README setup instruction to deal with changes to kotlin lib
- Compensates for the fact that the signAlgoTransaction method in the kotlin lib n oolongr has algoSdk