### PR TITLE
chore: remove unused text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,27 @@ cd ..
 cp bip32-ed25519-kotlin/build/*-release.aar arc52-android-wallet/app/libs/
 ```
 
+## AlgoD
+
+The AlgoD Client parameters have been set to:
+
+```kotlin
+private val algoDClient =
+        AlgodClient(
+                "http://10.0.2.2",
+                4001,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )
+```
+
+If you are running this app in an Android emulator on your computer, e.g. through Android Studio, this will correspond to port 4001 on your computer. If you've spun up a a localnet/sandbox with Algokit it will interact with it.
+
+```
+algokit localnet start
+```
+
 ## Send a Transaction
 
 Note that the default seed `exact remain north lesson program series excess lava material second riot error boss planet brick rotate scrap army riot banner adult fashion casino bamboo` should NOT be used in production.
 
-However, for testing the app, this seed produces the Algorand address `I7V63MENRB7L4K53PQGYRFQFI7ZWXD3N53XIGP5THNNT6BSAYWBFYGX4DE`. Funding it in your default local algokit sandbox environment (the default algod this app references too) should allow the app to make a successful transaction. If you don't fund it the app will simply return fail rather than providing transaction id.
+However, for testing the app, this seed produces the Algorand address `I7V63MENRB7L4K53PQGYRFQFI7ZWXD3N53XIGP5THNNT6BSAYWBFYGX4DE`. Funding it in your environment should allow the app to make a successful transaction and return the transaction id. If you don't fund it the app will simply return fail rather than providing transaction id.

--- a/app/src/main/res/layout/wallet.xml
+++ b/app/src/main/res/layout/wallet.xml
@@ -234,15 +234,6 @@
             android:id="@+id/statusTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
-        
-        <TextView
-            android:id="@+id/balanceTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:editable="false"
-            android:text="Algorand Balance will appear here"
-            android:textSize="12sp"/>
-
     </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/wallet.xml
+++ b/app/src/main/res/layout/wallet.xml
@@ -134,59 +134,13 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/keyindexNumberLayout" />
 
-        <View
-            android:id="@+id/separator1View"
-            android:layout_width="match_parent"
-            android:layout_height="20dp"
-            android:background="@android:color/darker_gray"
-            app:layout_constraintTop_toBottomOf="@+id/algorandAddressTextView"/>
-        
-        <LinearLayout
-        android:id="@+id/algoDLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintTop_toBottomOf="@+id/separator1View">
-        
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:editable="false"
-            android:text="Set Algo Daemon Values!"
-            android:textSize="18sp"/>
-
-        <EditText
-            android:id="@+id/algodApiUrlEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Algod API URL"
-            android:text="http://10.0.2.2"/>
-
-        <EditText
-            android:id="@+id/algodPortEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Port Number"
-            android:text="4001"
-            android:inputType="number"/>
-
-        <EditText
-            android:id="@+id/algodTokenEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Token"
-            android:text="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            android:inputType="text"
-            />
-
-    </LinearLayout>
 
         <View
             android:id="@+id/separator2View"
             android:layout_width="match_parent"
             android:layout_height="20dp"
             android:background="@android:color/darker_gray"
-            app:layout_constraintTop_toBottomOf="@+id/algoDLayout"/>
+            app:layout_constraintTop_toBottomOf="@+id/algorandAddressTextView"/>
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Currently we simply hard code the AlgoD client in the code and don't actually use the text fields to change AlgoD client. It causes unnecessary clutter and confusion so this PR removes it.